### PR TITLE
dsfrFileAttachCmp: sort picklist labels and values

### DIFF
--- a/force-app/main/extensions/lwc/dsfrFileAttachCmp/dsfrFileAttachCmp.js
+++ b/force-app/main/extensions/lwc/dsfrFileAttachCmp/dsfrFileAttachCmp.js
@@ -215,8 +215,8 @@ export default class DsfrFileAttachCmp extends LightningElement {
         if (this.isDebug) console.log('initOptions: recordId ', this.recordId);
         if (this.isDebug) console.log('initOptions: objectApiName ', this.objectApiName);
         let options = [];
-        let optionLabels = this.optionLabels.split(';');
-        let optionValues = this.optionValues.split(';');
+        let optionLabels = this.optionLabels.split(';').sort();
+        let optionValues = this.optionValues.split(';').sort();
         optionLabels.forEach((item,index) => {
             if (this.isDebug) console.log('initOptions: processing item ',item);
             if (this.isDebug) console.log('initOptions: at index ',index);


### PR DESCRIPTION
…alues

When the source of optionLabels and optionValues is {!Item.field._displayValue} and {!Item.field._rawValue} respectively, it could happen that they are not ordered correctly.  This proposed change prevents a situation where the select labels and values could be mismatched.