### PR TITLE
Toggle spinner at the end of connectedCallback

### DIFF
--- a/force-app/main/extensions/lwc/dsfrFormCmp/dsfrFormCmp.js
+++ b/force-app/main/extensions/lwc/dsfrFormCmp/dsfrFormCmp.js
@@ -213,6 +213,7 @@ export default class DsfrFormCmp extends LightningElement {
             });
             if (this.isDebug) console.log('connected: config request sent');
         }
+        this.toggleSpinner(true);
     }
 
 


### PR DESCRIPTION
This PR enables the loading spinner during form initialization. The spinner is now activated by setting toggleSpinner = true at the end of the connectedCallback, ensuring users see a loading indicator when forms take longer to load (especially with Salesforce Connect).

Toggled back to 'false' in the onLoad() handler.

Behavoiur before (simulating 5 second delay):

https://github.com/user-attachments/assets/f60be7f5-0905-47b9-b70d-20b71d2b8dc1


Behavoiur after fix:

https://github.com/user-attachments/assets/7206d46c-a7cc-4ae5-b23b-d0d8b0cf5f6c

